### PR TITLE
Without stacktrace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
 export default function deserializeError (obj) {
   if (!isSerializedError(obj)) return obj
   const err = new Error()
-  err.name = obj.name
-  err.message = obj.message
-  err.stack = obj.stack
+  Object.assign(err, obj)
   return err
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 export default function deserializeError (obj) {
   if (!isSerializedError(obj)) return obj
-  const err = new Error()
-  Object.assign(err, obj)
-  return err
+  return Object.assign(new Error(), {stack: undefined}, obj)
 }
 
 export function isSerializedError (obj) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,5 @@ export function isSerializedError (obj) {
   return obj &&
     typeof obj === 'object' &&
     typeof obj.name === 'string' &&
-    typeof obj.message === 'string' &&
-    typeof obj.stack === 'string'
+    typeof obj.message === 'string'
 }

--- a/test/is-serialized-error.js
+++ b/test/is-serialized-error.js
@@ -27,7 +27,7 @@ describe('isSerializedError', function () {
       assert.notOk(isSerializedError('error'))
       assert.notOk(isSerializedError(undefined))
       assert.notOk(isSerializedError(1))
-      assert.notOk(isSerializedError({name: 'shokai', message: 'hello'}))
+      assert.notOk(isSerializedError({name: 'shokai'}))
     })
   })
 })

--- a/test/is-serialized-error.js
+++ b/test/is-serialized-error.js
@@ -12,6 +12,15 @@ describe('isSerializedError', function () {
     })
   })
 
+  describe('name and message', function () {
+    it('is serialized error', function () {
+      assert.ok(isSerializedError({
+        name: 'SomeError',
+        message: 'some error'
+      }))
+    })
+  })
+
   describe('other object', function () {
     it('is not serialized error', function () {
       assert.notOk(isSerializedError(null))

--- a/test/serialize-deserialize.js
+++ b/test/serialize-deserialize.js
@@ -9,6 +9,7 @@ describe('serialize-deserialize', function () {
     let err = new Error('foobar')
     let err2 = deserializeError(serializeError(err))
     it('should be equal', function () {
+      assert.instanceOf(err2, Error)
       assert.equal(err.name, err2.name)
       assert.equal(err.message, err2.message)
       assert.equal(err.stack, err2.stack)
@@ -26,6 +27,7 @@ describe('serialize-deserialize', function () {
     let err = new FooError('barrrrrr')
     let err2 = deserializeError(serializeError(err))
     it('should be equal', function () {
+      assert.instanceOf(err2, Error)
       assert.equal(err.name, err2.name)
       assert.equal(err.message, err2.message)
       assert.equal(err.stack, err2.stack)
@@ -44,6 +46,19 @@ describe('serialize-deserialize', function () {
     it('should be equal', function () {
       assert.isString(err2)
       assert.equal(err, err2)
+    })
+  })
+
+  describe('without stacktrace', function () {
+    let err = new Error('foo')
+    delete err.stack
+    let err2 = deserializeError(serializeError(err))
+    it('should be equal', function () {
+      assert.instanceOf(err2, Error)
+      assert.equal(err.name, err2.name)
+      assert.equal(err.message, err2.message)
+      assert.equal(err.stack, err2.stack)
+      assert.equal(err.toString(), err2.toString())
     })
   })
 })


### PR DESCRIPTION
deserialize error from `name` and `message`.
